### PR TITLE
Force Google display results in English language

### DIFF
--- a/google_currency/__init__.py
+++ b/google_currency/__init__.py
@@ -183,11 +183,9 @@ def convert(currency_from, currency_to, amnt):
 
     if not isinstance(amnt, float) and not isinstance(amnt, int):
         raise TypeError("amount should be either int or float, passed %s" % type(amnt))
-
-    # url = "https://www.google.com/search?q=convert+{amount}+{frm}+to+{to}".format(amount = str(amnt),
-    #                                                                               frm    = currency_from,
-    #                                                                               to     = currency_to)
-    url = "http://216.58.221.46/search?q=convert+{amount}+{frm}+to+{to}".format(amount = str(amnt),
+        
+        
+    url = "https://www.google.com/search?q=convert+{amount}+{frm}+to+{to}&hl=en&lr=lang_en".format(amount = str(amnt),
                                                                                   frm    = currency_from,
                                                                                   to     = currency_to)
     currency_from = currency_from.upper()


### PR DESCRIPTION
Adding &hl=en&lr=lang_en query prams to force Google showing currency results in English. This is necessary because despite pointing browsers to Google.com most people see results (currency codes included) translated to their language. Netherlands people see 'Amerikaanse dollar' not 'United States Dollar'.